### PR TITLE
Bulk search

### DIFF
--- a/lib/matcon_client/query.rb
+++ b/lib/matcon_client/query.rb
@@ -37,8 +37,20 @@ module MatconClient
     end
 
     # Executes the built query. Will return a ModelClient::ResultSet
-    def result_set
+    def _result_set_with_get
+      if params[:where]
+        params[:where] = format_hash(params[:where])
+      end
       klass.requestor.get(nil, { query: to_s })
+    end
+
+    # Executes a query using a POST
+    def _result_set_with_post
+      klass.requestor.post('search', params.to_json)
+    end
+
+    def result_set
+      _result_set_with_post
     end
 
     # Resets all params to nil
@@ -93,7 +105,7 @@ module MatconClient
     # Sets the where parameter
     # Returns self
     def where(where_params)
-      @params[:where] = format_hash(where_params)
+      @params[:where] = where_params
       self
     end
 

--- a/lib/matcon_client/query.rb
+++ b/lib/matcon_client/query.rb
@@ -37,20 +37,17 @@ module MatconClient
     end
 
     # Executes the built query. Will return a ModelClient::ResultSet
-    def _result_set_with_get
-      if params[:where]
-        params[:where] = format_hash(params[:where])
-      end
+    def result_set_with_get
       klass.requestor.get(nil, { query: to_s })
     end
 
     # Executes a query using a POST
-    def _result_set_with_post
-      klass.requestor.post('search', params.to_json)
+    def result_set_with_post
+      klass.requestor.post('search', params.reject{|k,v| v.nil?}.to_json)
     end
 
     def result_set
-      _result_set_with_post
+      result_set_with_post
     end
 
     # Resets all params to nil
@@ -135,7 +132,14 @@ module MatconClient
     def to_s
       params.reduce([]) do |memo, obj|
         key, value = obj
-        memo.push("#{key}=#{value}") if value.present?
+
+        if value.present?
+          if key == :where
+            value = format_hash(value)
+          end
+          memo.push("#{key}=#{value}")
+        end
+
         memo
       end.join('&')
     end

--- a/spec/models/container_spec.rb
+++ b/spec/models/container_spec.rb
@@ -50,12 +50,12 @@ describe MatconClient::Container do
       }
 
       it 'returns all the materials from the slots' do
-        query = { '_id': { '$in': ['234', '345'] } }.to_json
+        query = { '_id': { '$in': ['234', '345'] } }
 
-        expect(MatconClient::Material.requestor).to receive(:get)
-          .with(nil, { query: 'where=' + query })
-          .and_return(result_set)
-
+        temp = double('temp')
+        allow(temp).to receive(:result_set).and_return(result_set)
+        expect(MatconClient::Material).to receive(:where).with(query).and_return(temp)
+        
         expect(container.materials).to all(be_instance_of(MatconClient::Material))
         expect(container.materials.length).to eq(3)
       end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -193,12 +193,21 @@ describe MatconClient::Query do
     end
   end
 
-  describe '#result_set' do
+  describe '#result_set_with_get' do
     it 'should create a result set by calling the klass requestor with its query string' do
       expect(@requestor).to receive(:get).with(nil, { query: "page=2&max_results=30" })
 
-      @query.page(2).limit(30).result_set
+      @query.page(2).limit(30).result_set_with_get
     end
   end
+
+  describe '#result_set_with_post' do
+    it 'should create a result set by calling the klass requestor with its query string' do
+      expect(@requestor).to receive(:post).with('search', { page: 2, max_results: 30}.to_json )
+
+      @query.page(2).limit(30).result_set_with_post
+    end
+  end
+
 
 end


### PR DESCRIPTION
This code requires the addition of the /search path in the aker-materials, as this client is sending the requests with a POST to /search, instead of with GET to the collection path (materials, containers, ...)